### PR TITLE
Creates the MC before pushing the image

### DIFF
--- a/oot-ice.sh
+++ b/oot-ice.sh
@@ -62,9 +62,13 @@ build_image () {
     -t ${REGISTRY}/${DRIVER_IMAGE}:${TAG}
   exit_on_error $?
 
+}
+
+push_image () {
   podman push --tls-verify=false ${REGISTRY}/${DRIVER_IMAGE}:${TAG}
   exit_on_error $?
   rm -rf ${TEMP_DIR}
+
 }
 
 generate_machine_config () {
@@ -191,3 +195,5 @@ fi
 build_image
 
 generate_machine_config
+
+push_image


### PR DESCRIPTION
Sometimes you cannot login at the same time to quay.io for pulling the release information and also for pushing the result image into your local namespace. In my case I need two authentication tokens. That ends up by showing an error when pulling the image and avoiding the creation of the MC. The pushing can be done at a later step, since I can just login with the proper user and push the image, but then I am missing the MC.

This PR just creates a new function and is executed after the MC is created. The MC is created if the image is built (not pushed)

Signed-off-by: Alberto Losada <alosadag@redhat.com>