### PR TITLE
fixes kmod install package due to a base repo renamed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM ${IMAGE}
 ARG DRIVER_VER
 ARG KERNEL_VERSION
 
-RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos -y kmod; microdnf clean all
+RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos-rpms -y kmod; microdnf clean all
 
 COPY --from=builder /build/ice-$DRIVER_VER/src/ice.ko /ice-driver/
 COPY --from=builder /build/ice-$DRIVER_VER/ddp/ /ddp/


### PR DESCRIPTION
kmod/insmod/rmod is not installed due to the repo has been renamed. This is the build:

```
[2/2] STEP 4/8: RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos -y kmod; microdnf clean all

(microdnf:7): librhsm-WARNING **: 10:10:16.122: Found 0 entitlement certificates

(microdnf:7): librhsm-WARNING **: 10:10:16.123: Found 0 entitlement certificates
error: repo ubi-8-baseos not found
```
This is the new name of the repo:

```
repo id                                                                repo name                                                                              
ubi-8-appstream-rpms                                                   Red Hat Universal Base Image 8 (RPMs) - AppStream                                      
ubi-8-baseos-rpms                                                      Red Hat Universal Base Image 8 (RPMs) - BaseOS                                         
ubi-8-codeready-builder-rpms                                           Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder                              

[root@fff2c6b02adc /]# microdnf install --disablerepo=* --enablerepo=ubi-8-baseos-rpms -y kmod
Installing:                                                                                                                                                   
 kmod-25-19.el8.x86_64                                                                                         ubi-8-baseos-rpms                      129.2 kB
```

Signed-off-by: Alberto Losada <alosadag@redhat.com>