### PR TITLE
Add support for Logan Beach cards and multiple PTP

### DIFF
--- a/ptp-config.sh
+++ b/ptp-config.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -eu
 
-ETH=$(grep 000e /sys/class/net/*/device/subsystem_device | awk -F"/" '{print $5}' | head -n 1)
+ETH=$(grep -e 000e -e 000f /sys/class/net/*/device/subsystem_device | awk -F"/" '{print $5}')
 
-echo 0 2 > /sys/class/net/$ETH/device/ptp/ptp*/pins/U.FL2
-echo 0 1 > /sys/class/net/$ETH/device/ptp/ptp*/pins/U.FL1
-echo 0 2 > /sys/class/net/$ETH/device/ptp/ptp*/pins/SMA2
-echo 0 1 > /sys/class/net/$ETH/device/ptp/ptp*/pins/SMA1
+for DEV in $ETH; do
+  if [ -f /sys/class/net/$DEV/device/ptp/ptp*/pins/U.FL2 ]; then
+    echo 0 2 > /sys/class/net/$DEV/device/ptp/ptp*/pins/U.FL2
+    echo 0 1 > /sys/class/net/$DEV/device/ptp/ptp*/pins/U.FL1
+    echo 0 2 > /sys/class/net/$DEV/device/ptp/ptp*/pins/SMA2
+    echo 0 1 > /sys/class/net/$DEV/device/ptp/ptp*/pins/SMA1
+  fi
+done
 
 echo "Disabled all SMA and U.FL Connections"


### PR DESCRIPTION
The Intel Logan Beach card has a subsystem device value of 0x000f, as opposed to 0x000e for Westport Channel. We can modify the ptp-config.sh script to support both.

Also, since we could have more than one card with PTP support, check for the existance of the pins directory on all identified cards, instead of hardcoding the first one.